### PR TITLE
[bugfix] Corrected typo for DMD button A

### DIFF
--- a/ArduinoCode/MotoButtons2.ino
+++ b/ArduinoCode/MotoButtons2.ino
@@ -640,7 +640,7 @@ void mapButtonsToKeyReport()
       keyReport[i] = DMD_KEY_CENTER;
       ++i;
     }
-    if (!button_A_state & button_A_flipped && !button_B_state)
+    if (!button_A_state && button_A_flipped && !button_B_state)
     {
       button_A_flipped = false;
       forceKeyReport = true;


### PR DESCRIPTION
Corrected a typo in the DMD part of mapButtonsToKeyReport() when button A is pressed